### PR TITLE
update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Trident is the python API scripting for Aquarium.
 
 ## Documentation
 
-[API documentation can be found here at klavinslab.org/trident](http://www.klavinslab.org/trident)
+[API documentation can be found here at http://aquariumbio.github.io/trident](http://aquariumbio.github.io/trident)
 
 ## Requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 name = "pydent"
 version = "1.0.0"
 description = "Aquarium's Python API for planning, executing, and analyzing scientific experiments."
-documentation = "https://www.klavinslab.org/trident"
-repository = "https://www.github.com/klavinslab/trident"
-homepage = "https://www.github.com/klavinslab/trident"
+documentation = "http://aquariumbio.github.io/trident"
+repository = "https://www.github.com/aquariumbio/trident"
+homepage = "https://www.github.com/aquariumbio/trident"
 authors = ["jvrana <justin.vrana@gmail.com>", "Ben Keller <bjkeller@uw.edu>", "Eric Klavins <klavins@uw.edu>"]
 readme = 'README.md'
 license = "MIT"


### PR DESCRIPTION
This pull request updates the links to the repository and documentation in the `pyproject.toml` and the link to the documentation in the README.md. The `pyproject.toml` repository and documentation links are used on the PyPI repo page. On next minor release, these links on the PyPI will be fixed from this pull request.